### PR TITLE
HV-156 - Rename grafana into cloudian-grafana, conflict and provide grafana.

### DIFF
--- a/build.go
+++ b/build.go
@@ -369,11 +369,17 @@ func createPackage(options linuxPackageOptions) {
 		"--config-files", options.systemdServiceFilePath,
 		"--after-install", options.postinstSrc,
 
+		// cloudian customization
+		// conflict with grafana so it can't be installed at the same time
+		// but also provide it, so other software depending on it can use us as dep
+		"--provides", "grafana",
+		"--conflicts", "grafana",
+
 		"--version", linuxPackageVersion,
 		"-p", "./dist",
 	}
 
-	name := "grafana"
+	name := "cloudian-grafana"
 	if enterprise {
 		name += "-enterprise"
 		args = append(args, "--replaces", "grafana")

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "author": "Grafana Labs",
+  "author": "Grafana Labs and Cloudian, Inc.",
   "license": "Apache-2.0",
   "private": true,
-  "name": "grafana",
+  "name": "cloudian-grafana",
   "version": "6.5.3",
   "repository": {
     "type": "git",
-    "url": "http://github.com/grafana/grafana.git"
+    "url": "http://github.com/cloudian/grafana.git"
   },
   "devDependencies": {
     "@babel/core": "7.6.4",


### PR DESCRIPTION
CAUSE/FIX: We had grafana pakaged in {{grafana}}. If any client accidentally upgrades grafana, we lose all our customization.s Rename grafana to cloudian-grafana and conflict to it so it can't be installed at the same time and provide grafana so other packages that depend on grafana can use ours.
MY VERIFICATION STEPS:

* `pkgs/grafana/cloudian-grafana_6.5.3_amd64.deb` exists.
* It has the proper fields:
```
dpkg-deb --field pkgs/grafana/cloudian-grafana_6.5.3_amd64.deb 
Package: cloudian-grafana
Version: 6.5.3
License: "Apache 2.0"
Vendor: @nimbus
Architecture: amd64
Maintainer: Cloudian Engineering <cloudian-eng@cloudian.com>
Installed-Size: 177633
Depends: adduser, libfontconfig1
Conflicts: grafana
Provides: grafana
Section: default
Priority: extra
Homepage: https://cloudian.com
Description: Grafana with some customizations.
```
OTHER VERIFICATION ADVICE:

* Run the OVA, check with apt show cloudian-grafana that the package is installed and has the right fields.
* Maybe also try to install grafana and check that the Conflicts field prevents for doing so.
* I don't know any package that depends on grafana to test the Provides field.

IMPACT OF THE FIX (PERFORMANCE, API, UPGRADE):
FOUND IN (VERSIONS): 1.0
RELEASENOTES: