### PR TITLE
HIQ-448  Apply Cloudian customizations to latest Grafana version (7.5.3)

### DIFF
--- a/packages/grafana-ui/.storybook/manager-head.html
+++ b/packages/grafana-ui/.storybook/manager-head.html
@@ -1,1 +1,1 @@
-<link rel="icon" href="./fav32.png" />
+<link rel="icon" href="./cloudian_logo_alt.png" />

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -393,7 +393,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		AppName:                 setting.ApplicationName,
 		AppNameBodyClass:        getAppNameBodyClass(hs.License.HasValidLicense()),
 		FavIcon:                 "public/img/cloudian_logo_alt.png",
-		AppleTouchIcon:          "public/img/apple-touch-icon.png",
+		AppleTouchIcon:          "public/img/cloudian_logo_alt.png",
 		AppTitle:                "Cloudian® HyperIQ",
 		NavTree:                 navTree,
 		Sentry:                  &hs.Cfg.Sentry,

--- a/pkg/services/alerting/notifiers/discord.go
+++ b/pkg/services/alerting/notifiers/discord.go
@@ -99,7 +99,7 @@ func (dn *DiscordNotifier) Notify(evalContext *alerting.EvalContext) error {
 
 	footer := map[string]interface{}{
 		"text":     "Grafana v" + setting.BuildVersion,
-		"icon_url": "https://grafana.com/assets/img/fav32.png",
+		"icon_url": "https://grafana.com/assets/img/cloudian_logo_alt.png",
 	}
 
 	color, _ := strconv.ParseInt(strings.TrimLeft(evalContext.GetStateModel().Color, "#"), 16, 0)

--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -150,7 +150,7 @@ func (hc *HipChatNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"title":       evalContext.GetNotificationTitle(),
 		"description": message,
 		"icon": map[string]interface{}{
-			"url": "https://grafana.com/assets/img/fav32.png",
+			"url": "https://grafana.com/assets/img/cloudian_logo_alt.png",
 		},
 		"date":       evalContext.EndTime.Unix(),
 		"attributes": attributes,

--- a/pkg/services/alerting/notifiers/slack.go
+++ b/pkg/services/alerting/notifiers/slack.go
@@ -270,7 +270,7 @@ func (sn *SlackNotifier) Notify(evalContext *alerting.EvalContext) error {
 		"fallback":    evalContext.GetNotificationTitle(),
 		"fields":      fields,
 		"footer":      "Grafana v" + setting.BuildVersion,
-		"footer_icon": "https://grafana.com/assets/img/fav32.png",
+		"footer_icon": "https://grafana.com/assets/img/cloudian_logo_alt.png",
 		"ts":          time.Now().Unix(),
 	}
 	if sn.NeedsImage() && imageURL != "" {

--- a/pkg/services/alerting/notifiers/slack_test.go
+++ b/pkg/services/alerting/notifiers/slack_test.go
@@ -65,7 +65,7 @@ func TestSlackNotifier(t *testing.T) {
                       "recipient": "#ds-opentsdb",
                       "username": "Grafana Alerts",
                       "icon_emoji": ":smile:",
-                      "icon_url": "https://grafana.com/img/fav32.png",
+                      "icon_url": "https://grafana.com/img/cloudian_logo_alt.png",
                       "mentionUsers": "user1, user2",
                       "mentionGroups": "group1, group2",
                       "mentionChannel": "here",
@@ -90,7 +90,7 @@ func TestSlackNotifier(t *testing.T) {
 				So(slackNotifier.Recipient, ShouldEqual, "#ds-opentsdb")
 				So(slackNotifier.Username, ShouldEqual, "Grafana Alerts")
 				So(slackNotifier.IconEmoji, ShouldEqual, ":smile:")
-				So(slackNotifier.IconURL, ShouldEqual, "https://grafana.com/img/fav32.png")
+				So(slackNotifier.IconURL, ShouldEqual, "https://grafana.com/img/cloudian_logo_alt.png")
 				So(slackNotifier.MentionUsers, ShouldResemble, []string{"user1", "user2"})
 				So(slackNotifier.MentionGroups, ShouldResemble, []string{"group1", "group2"})
 				So(slackNotifier.MentionChannel, ShouldEqual, "here")
@@ -104,7 +104,7 @@ func TestSlackNotifier(t *testing.T) {
                       "recipient": "#ds-opentsdb",
                       "username": "Grafana Alerts",
                       "icon_emoji": ":smile:",
-                      "icon_url": "https://grafana.com/img/fav32.png",
+                      "icon_url": "https://grafana.com/img/cloudian_logo_alt.png",
                       "mentionUsers": "user1, user2",
                       "mentionGroups": "group1, group2",
                       "mentionChannel": "here",
@@ -133,7 +133,7 @@ func TestSlackNotifier(t *testing.T) {
 				So(slackNotifier.Recipient, ShouldEqual, "#ds-opentsdb")
 				So(slackNotifier.Username, ShouldEqual, "Grafana Alerts")
 				So(slackNotifier.IconEmoji, ShouldEqual, ":smile:")
-				So(slackNotifier.IconURL, ShouldEqual, "https://grafana.com/img/fav32.png")
+				So(slackNotifier.IconURL, ShouldEqual, "https://grafana.com/img/cloudian_logo_alt.png")
 				So(slackNotifier.MentionUsers, ShouldResemble, []string{"user1", "user2"})
 				So(slackNotifier.MentionGroups, ShouldResemble, []string{"group1", "group2"})
 				So(slackNotifier.MentionChannel, ShouldEqual, "here")


### PR DESCRIPTION
**CAUSE/FIX:** fixed favor icon for firefox. Tested with firefox to make sure when browsing history the icon of HIQ is showing up correctly.