### PR TITLE
HIQ-448  Apply Cloudian customizations to latest Grafana version (7.5.3)

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -280,7 +280,6 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 	if c.IsGrafanaAdmin {
 		adminNavLinks := []*dtos.NavLink{
 			{Text: "Users", Id: "global-users", Url: setting.AppSubUrl + "/admin/users", Icon: "user"},
-			{Text: "Orgs", Id: "global-orgs", Url: setting.AppSubUrl + "/admin/orgs", Icon: "building"},
 			{Text: "Settings", Id: "server-settings", Url: setting.AppSubUrl + "/admin/settings", Icon: "sliders-v-alt"},
 			{Text: "Stats", Id: "server-stats", Url: setting.AppSubUrl + "/admin/stats", Icon: "graph-bar"},
 		}
@@ -293,7 +292,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 
 		navTree = append(navTree, &dtos.NavLink{
 			Text:         "Server Admin",
-			SubTitle:     "Manage all users & orgs",
+			SubTitle:     "Manage all users",
 			HideFromTabs: true,
 			Id:           "admin",
 			Icon:         "shield",

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -9,7 +9,7 @@ import (
 var (
 	ErrUserNotFound      = errors.New("user not found")
 	ErrUserAlreadyExists = errors.New("user already exists")
-	ErrLastGrafanaAdmin  = errors.New("cannot remove last grafana admin")
+	ErrLastGrafanaAdmin  = errors.New("cannot remove last admin")
 )
 
 type Password string

--- a/pkg/services/notifications/send_email_integration_test.go
+++ b/pkg/services/notifications/send_email_integration_test.go
@@ -59,7 +59,7 @@ func TestEmailIntegrationTest(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			sentMsg := <-ns.mailQueue
-			So(sentMsg.From, ShouldEqual, "Grafana Admin <from@address.com>")
+			So(sentMsg.From, ShouldEqual, "Admin <from@address.com>")
 			So(sentMsg.To[0], ShouldEqual, "asdf@asdf.com")
 			err = ioutil.WriteFile("../../../tmp/test_email.html", []byte(sentMsg.Body), 0777)
 			So(err, ShouldBeNil)

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -545,7 +545,7 @@ func TestUserDataAccess(t *testing.T) {
 			})
 		})
 
-		Convey("Given one grafana admin user", func() {
+		Convey("Given one admin user", func() {
 			var err error
 			createUserCmd := &models.CreateUserCommand{
 				Email:   fmt.Sprint("admin", "@test.com"),

--- a/public/app/features/admin/UserListAdminPage.tsx
+++ b/public/app/features/admin/UserListAdminPage.tsx
@@ -118,7 +118,7 @@ const renderUser = (user: UserDTO) => {
       <td className="link-td">
         {user.isAdmin && (
           <a href={editUrl}>
-            <Tooltip placement="top" content="Grafana Admin">
+            <Tooltip placement="top" content="Admin">
               <Icon name="shield" />
             </Tooltip>
           </a>

--- a/public/app/features/admin/UserPermissions.tsx
+++ b/public/app/features/admin/UserPermissions.tsx
@@ -58,7 +58,7 @@ export class UserPermissions extends PureComponent<Props, State> {
             <table className="filter-table form-inline">
               <tbody>
                 <tr>
-                  <td className="width-16">Grafana Admin</td>
+                  <td className="width-16">Admin</td>
                   {isEditing ? (
                     <td colSpan={2}>
                       <RadioButtonGroup


### PR DESCRIPTION
CAUSE/FIX: change "grafana admin" into "admin" and removed orgs option for server admin.