### PR TITLE
HIQ-647  Grafana should be upgraded to at least 7.5.12 to patch CVE's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,10 @@ WORKDIR $GOPATH/src/github.com/grafana/grafana
 
 COPY go.mod go.sum ./
 
+COPY pkg pkg
+
 RUN go mod verify
 
-COPY pkg pkg
 COPY build.go package.json ./
 
 RUN go run build.go build

--- a/packages/grafana-data/src/types/theme.ts
+++ b/packages/grafana-data/src/types/theme.ts
@@ -161,7 +161,7 @@ export interface GrafanaTheme extends GrafanaThemeCommons {
     // Accent colors
     redBase: string;
     redShade: string;
-	green: string;
+    green: string;
     greenBase: string;
     greenShade: string;
     red: string;


### PR DESCRIPTION
**_CAUSE/FIX:_**  build fix