### PR TITLE
HIQ-1098   404 error in Connection page

### DIFF
--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -7,7 +7,6 @@ import { StoreState, useSelector } from 'app/types';
 
 import { ROUTES } from './constants';
 import {
-  ConnectDataPage,
   DataSourceDashboardsPage,
   DataSourceDetailsPage,
   DataSourcesListPage,
@@ -17,7 +16,6 @@ import {
 
 export default function Connections() {
   const navIndex = useSelector((state: StoreState) => state.navIndex);
-  const isConnectDataPageOverriden = Boolean(navIndex['standalone-plugin-page-/connections/connect-data']);
 
   const YourConnectionsPage =
     navIndex['connections-your-connections'].children && navIndex['connections-your-connections'].children?.length > 1
@@ -34,17 +32,14 @@ export default function Connections() {
       }}
     >
       <Switch>
-        {/* Redirect to "Connect data" by default */}
-        <Route exact sensitive path={ROUTES.Base} component={() => <Redirect to={ROUTES.ConnectData} />} />
+        {/* Redirect to "Your connections" by default */}
+        <Route exact sensitive path={ROUTES.Base} component={() => <Redirect to={ROUTES.YourConnections} />} />
         <Route exact sensitive path={ROUTES.YourConnections} component={YourConnectionsPage} />
         <Route exact sensitive path={ROUTES.DataSources} component={DataSourcesListPage} />
         <Route exact sensitive path={ROUTES.DataSourcesDetails} component={DataSourceDetailsPage} />
         <Route exact sensitive path={ROUTES.DataSourcesNew} component={NewDataSourcePage} />
         <Route exact sensitive path={ROUTES.DataSourcesEdit} component={EditDataSourcePage} />
         <Route exact sensitive path={ROUTES.DataSourcesDashboards} component={DataSourceDashboardsPage} />
-
-        {/* "Connect data" page - we don't register a route in case a plugin already registers a standalone page for it */}
-        {!isConnectDataPageOverriden && <Route exact sensitive path={ROUTES.ConnectData} component={ConnectDataPage} />}
 
         {/* Not found */}
         <Route component={() => <Redirect to="/notfound" />} />


### PR DESCRIPTION
**CAUSE/FIX:**  Connections page by default will redirect to connect-data page which we don't want to show it to user. It is fixed by removing routing to connect-data page completely and set default redirect of connections page to your-connections page instead.