### PR TITLE
  HIQ-1073   HIQ upgrade does not update documentation link under the GUI

### DIFF
--- a/public/app/core/components/Footer/Footer.tsx
+++ b/public/app/core/components/Footer/Footer.tsx
@@ -20,7 +20,7 @@ export let getFooterLinks = (): FooterLink[] => {
       id: 'documentation',
       text: t('nav.help/documentation', 'Documentation'),
       icon: 'document-info',
-      url: 'public/docs/hyperiq_guide.pdf',
+      url: 'public/docs/hyperiq_guide_2_0.pdf',
     },
   ];
 };


### PR DESCRIPTION
CAUSE/FIX: uploaded help doc path to 2.0 help doc (hyperiq_guide_2_0.pdf)