### PR TITLE
Remove suffix from tag, just put it in tag directly

### DIFF
--- a/cloudian_build.sh
+++ b/cloudian_build.sh
@@ -16,9 +16,8 @@ echo $PASSWORD | docker login quay.io -u $USERNAME --password-stdin
 cd $(dirname $0)
 
 # Determine TAG for this build
-LOGINSIGHT_SUFFIX='-loginsight'
 REPO=quay.io/cloudian/grafana
-TAG="$(git describe)${LOGINSIGHT_SUFFIX}"
+TAG="$(git describe)"
 
 # Strip off Git commit for release build
 if [ "$1" = "release" ]; then


### PR DESCRIPTION
Realized that we can just should `-loginsight` in the Git tag directly instead of the build script