### PR TITLE
HIQ-1405   Grafana "Open Source" link goes to wrong location

### DIFF
--- a/pkg/services/licensing/oss.go
+++ b/pkg/services/licensing/oss.go
@@ -34,11 +34,7 @@ func (*OSSLicensingService) ContentDeliveryPrefix() string {
 }
 
 func (l *OSSLicensingService) LicenseURL(showAdminLicensingPage bool) string {
-	if showAdminLicensingPage {
-		return l.Cfg.AppSubURL + "/admin/upgrading"
-	}
-
-	return "https://grafana.com/oss/grafana?utm_source=grafana_footer"
+	return "https://github.com/cloudian/grafana"
 }
 
 func (*OSSLicensingService) EnabledFeatures() map[string]bool {


### PR DESCRIPTION
**CAUSE/FIX:** Fixed "Open Source" link to point to public repository for AGPL compliance