### PR TITLE
LOGI-312: Change dashboard filter to use proper LogInsight tag

### DIFF
--- a/cloudian_loginsight.sh
+++ b/cloudian_loginsight.sh
@@ -7,10 +7,8 @@ echo "$SELF"
 
 # Files to not change:
 # hyperiq_guide.pdf
-# navtree.go: Keep 'HyperIQ' tag for dashboard links
 find "$PWD" -type f \
   -not -name "$SELF" \
   -not -name hyperiq_guide.pdf \
-  -not -name navtree.go \
   -print0 |
   xargs -0 sed -i 's/HyperIQ/LogInsight/g'

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -117,7 +117,7 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 			Id:         navtree.NavIDDashboards,
 			SubTitle:   "Create and manage dashboards to visualize your data",
 			Icon:       "apps",
-			Url:        s.cfg.AppSubURL + "/dashboards?tag=HyperIQ",
+			Url:        s.cfg.AppSubURL + "/dashboards?tag=LogInsight",
 			SortWeight: navtree.WeightDashboard,
 			Children:   dashboardChildLinks,
 		}


### PR DESCRIPTION
CAUSE/FIX: Changed LogInsight "Dashboards" link to use proper "LogInsight" tag when filtering dashboards

VERIFICATION STEPS:
- Deploy LogInsight
- Click on "Dashboards" in Grafana's side bar menu, verify the page linked to is `LOGINSIGHT_IP:PORT/dashboards?tag=LogInsight` and that all LogInsight dashboards are listed