### PR TITLE
HIQ-1446   Latest Grafana licensing - Do we need to change how we rebrand Grafana to HIQ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![Grafana Logo (Light)](docs/logo-horizontal.png#gh-light-mode-only)
 ![Grafana Logo (Dark)](docs/logo-horizontal-dark.png#gh-dark-mode-only)
 
+> **This is a modified version of Grafana maintained by Cloudian, Inc. Last modified: June 2026.**
+> Source code for this modified version is available at https://github.com/cloudian/grafana
+
 The open-source platform for monitoring and observability
 
 [![License](https://img.shields.io/github/license/grafana/grafana)](LICENSE)

--- a/pkg/services/licensing/oss.go
+++ b/pkg/services/licensing/oss.go
@@ -1,3 +1,4 @@
+// Copyright 2025 Cloudian, Inc. (modified from original Grafana source)
 package licensing
 
 import (

--- a/public/app/core/components/Branding/Branding.tsx
+++ b/public/app/core/components/Branding/Branding.tsx
@@ -1,3 +1,4 @@
+// Copyright 2025 Cloudian, Inc. (modified from original Grafana source)
 import { css, cx } from '@emotion/css';
 import { FC } from 'react';
 


### PR DESCRIPTION
## HIQ-1446 — AGPL 3.0 compliance: modified version notices

Adds the required notices for our Cloudian fork of Grafana under AGPL Section 5a.

### Changes
- `README.md` — Added prominent notice that this is a modified version maintained by Cloudian, Inc., with a link to the source repo (`github.com/cloudian/grafana`)
- `public/app/core/components/Branding/Branding.tsx` — Added Cloudian copyright header
- `pkg/services/licensing/oss.go` — Added Cloudian copyright header

### Note
> `github.com/cloudian/grafana` must remain **public** for Section 13 compliance (network users must be able to access the source). Please confirm the repo visibility is set to public on GitHub.