### PR TITLE
Fix: PostgreSQL datasource "Could not load plugin" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,9 @@ COPY emails emails
 # Run webpack directly to bypass NX's SQLite task-hashing DB which fails on Docker's overlay filesystem
 RUN NODE_ENV=production node_modules/.bin/webpack --config scripts/webpack/webpack.prod.js
 
+# Build postgres datasource plugin separately (has its own webpack config, not bundled in main webpack)
+RUN cd public/app/plugins/datasource/grafana-postgresql-datasource && yarn build
+
 # Golang build stage
 FROM ${GO_IMAGE} AS go-builder
 

--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,8 @@ build-cli: ## Build Grafana CLI application.
 build-js: ## Build frontend assets.
 	@echo "build frontend"
 	yarn run build
+	@echo "build postgres plugin"
+	yarn workspace @grafana-plugins/grafana-postgresql-datasource run build
 
 PLUGIN_ID ?=
 


### PR DESCRIPTION
## Fix: PostgreSQL datasource "Could not load plugin" error

### Problem

Users were seeing this alert when using a PostgreSQL datasource:

> `Postgres plugin failed Error: Could not load plugin`

### Root Cause

The `grafana-postgresql-datasource` plugin has its own webpack config and is **not** bundled into the main Grafana webpack build (unlike `cloudwatch`, `prometheus`, etc.). At runtime, the frontend falls back to loading it via SystemJS, which looks for a compiled `dist/module.js` on disk — but that file was never produced, causing the load to fail.

The error chain:
1. `importPluginModule()` checks `isBuiltinPluginPath()` → returns `false` (postgres not in `built_in_plugins.ts`)
2. Falls through to `SystemJS.import(modulePath)`
3. `dist/module.js` doesn't exist → throws `Error: Could not load plugin`
4. `datasource_srv.ts` catches it and emits the user-visible alert

### Fix

Added the postgres plugin build as an explicit step in both build paths:

- **`Dockerfile`** — runs after the main webpack step in the `js-builder` stage
- **`Makefile` (`build-js` target)** — runs after `yarn run build`

```dockerfile
# Build postgres datasource plugin separately (has its own webpack config, not bundled in main webpack)
RUN cd public/app/plugins/datasource/grafana-postgresql-datasource && yarn build